### PR TITLE
Add cc license information on the frontpage.

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,5 +122,5 @@ Why Chaplin
 
 <footer>
   <p><small>Hosted on <a href="https://github.com/chaplinjs/chaplinjs.github.com">GitHub Pages</a></small></p>
-  <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/deed.en_US"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-sa/3.0/80x15.png" /></a><br />The content on this website is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/deed.en_US">Creative Commons Attribution-ShareAlike 3.0 Unported License</a>.
+  <a rel="license" href="http://creativecommons.org/licenses/by/3.0/deed.en_US"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by/3.0/80x15.png" /></a><br />The content on this website is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/3.0/deed.en_US">Creative Commons Attribution 3.0 Unported License</a>.
 </footer>


### PR DESCRIPTION
Added a CC license for the text on the website. 

Wikipedia thinks the chaplin.js article is too similar to the website (list of features, etc.) and this notation will make wikipedia happy.
